### PR TITLE
Fix book detail

### DIFF
--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/adapter/reading_history/BookDetailReadingHistoryAdapter.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/adapter/reading_history/BookDetailReadingHistoryAdapter.kt
@@ -29,8 +29,15 @@ class BookDetailReadingHistoryAdapter : RecyclerView.Adapter<ReadingHistoryViewH
     fun setReadingHistoryListData(newReadingHistoryList : List<ReadingHistory>) {
         readingHistoryList.clear()
         readingHistoryList.addAll(newReadingHistoryList)
-        maxReadingValue = newReadingHistoryList.maxOfOrNull { it.time } ?: 100
+
+        setMaxReadingValue(newReadingHistoryList)
         notifyDataSetChanged()
+    }
+
+    private fun setMaxReadingValue(readingHistoryList : List<ReadingHistory>, minOfMaxTime : Int = 300) {
+        maxReadingValue = readingHistoryList.maxOfOrNull { it.time }?.let { maxValue ->
+            max(maxValue, minOfMaxTime)
+        } ?: minOfMaxTime
     }
 
 }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/book_detail/BookDetailFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/book_detail/BookDetailFragment.kt
@@ -40,8 +40,6 @@ class BookDetailFragment : ViewBindingFragment<FragmentBookdetailBinding>(Fragme
     private lateinit var onBackPressedCallback: OnBackPressedCallback
     private val args : BookDetailFragmentArgs by navArgs()
 
-    // getParcelableArray 사용시 type cast 에러 발생
-    // 참고 : https://stackoverflow.com/questions/51714927/pass-array-in-intent-using-parcelable
     private val timerScreenLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         @Suppress("UNCHECKED_CAST")
         val response = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -115,7 +113,6 @@ class BookDetailFragment : ViewBindingFragment<FragmentBookdetailBinding>(Fragme
         binding.btnBookdetailTimer.setOnClickListener {
             val intent = Intent(requireActivity(), TimerActivity::class.java)
             intent.putExtra("book_id", args.bookId)
-            startActivity(intent)
             timerScreenLauncher.launch(intent)
         }
 


### PR DESCRIPTION
책 상세 화면에서 아래 요소 수정

- 타이머 버튼 클릭시 타이머 화면이 2번 호출되던 문제 수정
- 독서 기록 그래프에서 1분 미만 기록들로 가득 차 있을 때, 0분임에도 불구하고 최대 독서 기록으로 설정되는 문제 수정
(300초를 최댓값의 최소 기준으로 설정)