### PR TITLE
Feature today oneline

### DIFF
--- a/app/src/main/java/com/bookmark/bookmark_oneday/data/datasource/oneline_datasource/OnelineDataSource.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/data/datasource/oneline_datasource/OnelineDataSource.kt
@@ -1,12 +1,12 @@
 package com.bookmark.bookmark_oneday.data.datasource.oneline_datasource
 
 import com.bookmark.bookmark_oneday.data.models.dto.OneLineDto
+import com.bookmark.bookmark_oneday.data.models.request_body.RegisterOneLineRequestBody
 import com.bookmark.bookmark_oneday.domain.model.BaseResponse
-import com.bookmark.bookmark_oneday.domain.model.OneLineContent
 import com.bookmark.bookmark_oneday.domain.model.PagingData
 
 interface OnelineDataSource {
     suspend fun getOnelineList(perPage : Int, continuousToken : String, sortType : String) : BaseResponse<PagingData<OneLineDto>>
 
-    suspend fun registerOneline(oneLineContent: OneLineContent) : BaseResponse<Nothing>
+    suspend fun registerOneline(oneLineContent: RegisterOneLineRequestBody) : BaseResponse<Nothing>
 }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/data/datasource/oneline_datasource/RemoteOnelineDataSource.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/data/datasource/oneline_datasource/RemoteOnelineDataSource.kt
@@ -1,0 +1,63 @@
+package com.bookmark.bookmark_oneday.data.datasource.oneline_datasource
+
+import com.bookmark.bookmark_oneday.app.di.RetrofitModule
+import com.bookmark.bookmark_oneday.data.models.dto.OneLineDto
+import com.bookmark.bookmark_oneday.data.models.request_body.RegisterOneLineRequestBody
+import com.bookmark.bookmark_oneday.data.models.response_body.DefaultResponseBody
+import com.bookmark.bookmark_oneday.data.models.response_meta.PagingResponseMeta
+import com.bookmark.bookmark_oneday.domain.model.BaseResponse
+import com.bookmark.bookmark_oneday.domain.model.PagingData
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+import javax.inject.Inject
+
+class RemoteOnelineDataSource @Inject constructor(
+    @RetrofitModule.BookmarkOneDayClient retrofit : Retrofit
+) : OnelineDataSource {
+    private val service = retrofit.create(OnelineApi::class.java)
+
+    override suspend fun getOnelineList(
+        perPage: Int,
+        continuousToken: String,
+        sortType: String
+    ): BaseResponse<PagingData<OneLineDto>> {
+        val response = service.getOnelineList(sortType, perPage, continuousToken)
+        return if (response.isSuccessful && response.body() != null) {
+            val pagingData = PagingData(
+                dataList = response.body()!!.data,
+                nextPageToken = continuousToken + 1,
+                totalItemCount = response.body()!!.meta!!.totalCount,
+                isFinish = response.body()!!.data.size != perPage
+            )
+            BaseResponse.Success(pagingData)
+        } else {
+            val errorMessage = response.message()
+            val errorCode = response.code()
+            BaseResponse.Failure(errorCode, errorMessage)
+        }
+    }
+
+    override suspend fun registerOneline(oneLineContent: RegisterOneLineRequestBody): BaseResponse<Nothing> {
+        val response = service.registerOneline(oneLineContent)
+        return if (response.isSuccessful) {
+            BaseResponse.EmptySuccess
+        } else {
+            val errorMessage = response.message()
+            val errorCode = response.code()
+            BaseResponse.Failure(errorCode, errorMessage)
+        }
+    }
+}
+
+interface OnelineApi {
+    @GET("/v1/oneliner")
+    suspend fun getOnelineList(@Query("sortType") sortType : String, @Query("perPage") perPage : Int, @Query("continuousToken") continuousToken : String) : Response<DefaultResponseBody<List<OneLineDto>, PagingResponseMeta>>
+
+    @POST("/v1/oneliner")
+    suspend fun registerOneline(@Body params : RegisterOneLineRequestBody) : Response<ResponseBody>
+}

--- a/app/src/main/java/com/bookmark/bookmark_oneday/data/datasource/oneline_datasource/TestOnelineDataSource.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/data/datasource/oneline_datasource/TestOnelineDataSource.kt
@@ -1,8 +1,8 @@
 package com.bookmark.bookmark_oneday.data.datasource.oneline_datasource
 
 import com.bookmark.bookmark_oneday.data.models.dto.OneLineDto
+import com.bookmark.bookmark_oneday.data.models.request_body.RegisterOneLineRequestBody
 import com.bookmark.bookmark_oneday.domain.model.BaseResponse
-import com.bookmark.bookmark_oneday.domain.model.OneLineContent
 import com.bookmark.bookmark_oneday.domain.model.PagingData
 import kotlinx.coroutines.delay
 import javax.inject.Inject
@@ -112,7 +112,7 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
         ),
     )
 
-    override suspend fun registerOneline(oneLineContent: OneLineContent): BaseResponse<Nothing> {
+    override suspend fun registerOneline(oneLineContent: RegisterOneLineRequestBody): BaseResponse<Nothing> {
         delay(1500L)
         return BaseResponse.EmptySuccess
     }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/data/repository_impl/OnelineRepositoryImpl.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/data/repository_impl/OnelineRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.bookmark.bookmark_oneday.data.repository_impl
 
 import com.bookmark.bookmark_oneday.data.datasource.oneline_datasource.OnelineDataSource
 import com.bookmark.bookmark_oneday.data.models.dto.OneLineDto
+import com.bookmark.bookmark_oneday.data.models.request_body.RegisterOneLineRequestBody
 import com.bookmark.bookmark_oneday.domain.model.BaseResponse
 import com.bookmark.bookmark_oneday.domain.model.OneLine
 import com.bookmark.bookmark_oneday.domain.model.OneLineContent
@@ -37,6 +38,7 @@ class OnelineRepositoryImpl @Inject constructor(
     }
 
     override suspend fun registerOneLine(oneLineContent: OneLineContent): BaseResponse<Nothing> {
-        return dataSource.registerOneline(oneLineContent)
+        val requestBody = RegisterOneLineRequestBody.fromOnelineContent(oneLineContent = oneLineContent)
+        return dataSource.registerOneline(requestBody)
     }
 }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/TodayOnelineFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/TodayOnelineFragment.kt
@@ -13,6 +13,7 @@ import com.bookmark.bookmark_oneday.databinding.FragmentTodayOnelineBinding
 import com.bookmark.bookmark_oneday.presentation.adapter.today_oneline.TodayOnelineAdapter
 import com.bookmark.bookmark_oneday.presentation.base.DataBindingFragment
 import com.bookmark.bookmark_oneday.presentation.screens.home.HomeActivity
+import com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.model.ViewPagerPosition
 import com.bookmark.bookmark_oneday.presentation.screens.write_today_oneline.WriteTodayOnelineActivity
 import com.bookmark.bookmark_oneday.presentation.util.applyStatusBarPadding
 import com.bookmark.bookmark_oneday.presentation.util.collectLatestInLifecycle
@@ -20,7 +21,6 @@ import com.bookmark.bookmark_oneday.presentation.util.collectLatestInLifecycle
 class TodayOnelineFragment : DataBindingFragment<FragmentTodayOnelineBinding>(R.layout.fragment_today_oneline) {
 
     private val viewModel : TodayOnelineViewModel by activityViewModels()
-    private var isInit = true
     private val writeTodayOneLineScreenLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             viewModel.tryGetFirstPagingData()
@@ -61,7 +61,7 @@ class TodayOnelineFragment : DataBindingFragment<FragmentTodayOnelineBinding>(R.
 
                 if (state == ViewPager2.SCROLL_STATE_IDLE &&
                     previousState == ViewPager2.SCROLL_STATE_DRAGGING &&
-                    viewModel.state.value.currentPosition != 0
+                    viewModel.state.value.viewPagerPosition?.position != 0
                 ) {
                     viewModel.tryGetNextPagingData()
                 }
@@ -100,17 +100,16 @@ class TodayOnelineFragment : DataBindingFragment<FragmentTodayOnelineBinding>(R.
             (binding.pagerTodayOneline.adapter as TodayOnelineAdapter).submitList(state.onelineList)
             binding.progressTodayOnelineLoading.visibility = if (state.showLoading) View.VISIBLE else View.INVISIBLE
             state.userProfile?.let { binding.partialTodayOnlineToolbar.setWriterProfile(it) }
-            changeViewPagerPosition(state.currentPosition)
+            changeViewPagerPosition(state.viewPagerPosition)
             binding.pagerTodayOneline.isUserInputEnabled = !state.showLoading
         }
     }
 
-    private fun changeViewPagerPosition(position : Int?) {
-        if (position != null &&
-            binding.pagerTodayOneline.currentItem != position) {
+    private fun changeViewPagerPosition(viewPagerPosition: ViewPagerPosition?) {
+        if (viewPagerPosition != null &&
+            binding.pagerTodayOneline.currentItem != viewPagerPosition.position) {
             binding.pagerTodayOneline.post {
-                binding.pagerTodayOneline.setCurrentItem(position, !isInit)
-                isInit = false
+                binding.pagerTodayOneline.setCurrentItem(viewPagerPosition.position, viewPagerPosition.useAnimation)
             }
         }
     }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/model/TodayOnelineState.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/model/TodayOnelineState.kt
@@ -7,6 +7,6 @@ data class TodayOnelineState (
     val onelineList : List<OneLine> = listOf(),
     val showLoadingFail : Boolean = false,
     val showLoading : Boolean = false,
-    val currentPosition : Int ?= null,
+    val viewPagerPosition : ViewPagerPosition ?= null,
     val userProfile: UserProfile ?= null
 )

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/model/ViewPagerPosition.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/model/ViewPagerPosition.kt
@@ -1,0 +1,6 @@
+package com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.model
+
+data class ViewPagerPosition(
+    val position : Int,
+    val useAnimation : Boolean = true
+)

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/WriteTodayOnelineWriteFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/WriteTodayOnelineWriteFragment.kt
@@ -22,6 +22,7 @@ import com.bookmark.bookmark_oneday.presentation.screens.write_today_oneline.wri
 import com.bookmark.bookmark_oneday.presentation.util.applyBottomNavigationPadding
 import com.bookmark.bookmark_oneday.presentation.util.applyStatusBarPadding
 import com.bookmark.bookmark_oneday.presentation.util.collectLatestInLifecycle
+import com.bookmark.bookmark_oneday.presentation.util.dpToPx
 import com.bookmark.bookmark_oneday.presentation.util.getBottomNavigationHeight
 import com.bumptech.glide.Glide
 import dagger.hilt.android.AndroidEntryPoint
@@ -270,7 +271,9 @@ class WriteTodayOnelineWriteFragment : ViewBindingFragment<FragmentWriteTodayOne
     }
 
     private fun moveSettingViewY(translationY : Float) {
+        val bottomSettingViewHeight = dpToPx(requireContext(), 56)
         binding.partialWriteTodayOnelineTextAttrSetting.translationY = translationY
+        binding.partialWriteTodayOnelineContent.applyBottomViewTranslation(-translationY + bottomSettingViewHeight.toFloat())
     }
 
 }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/component/OnelineContentView.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/component/OnelineContentView.kt
@@ -31,8 +31,8 @@ class OnelineContentView(context : Context, attrs : AttributeSet) : FrameLayout(
     private var longClick = false
     private var moveAvailable = true
 
-    private var currentPositionX = NOT_INIT_FLOAT
-    private var currentPositionY = NOT_INIT_FLOAT
+    private var originalPositionX = NOT_INIT_FLOAT
+    private var originalPositionY = NOT_INIT_FLOAT
 
     init {
         val inflater = LayoutInflater.from(context)
@@ -132,8 +132,8 @@ class OnelineContentView(context : Context, attrs : AttributeSet) : FrameLayout(
                         (binding.clWriteTodayOnelineContent.y + contentViewHeight / 2)  / layoutHeight
                     )
 
-                    currentPositionX = binding.clWriteTodayOnelineContent.x
-                    currentPositionY = binding.clWriteTodayOnelineContent.y
+                    originalPositionX = binding.clWriteTodayOnelineContent.x
+                    originalPositionY = binding.clWriteTodayOnelineContent.y
 
                     if (longClick) {
                         longClick = false
@@ -236,6 +236,19 @@ class OnelineContentView(context : Context, attrs : AttributeSet) : FrameLayout(
 
         binding.clWriteTodayOnelineContent.x = positionX
         binding.clWriteTodayOnelineContent.y = positionY
+
+        originalPositionX = positionX
+        originalPositionY = positionY
+    }
+
+    fun applyBottomViewTranslation(translationY : Float) {
+        if (originalPositionY == NOT_INIT_FLOAT) return
+
+        if (layoutHeight - originalPositionY <= translationY) {
+            binding.clWriteTodayOnelineContent.y = layoutHeight - translationY - contentViewHeight
+        } else {
+            binding.clWriteTodayOnelineContent.y = originalPositionY
+        }
     }
 
     fun setFont(fontResourceId : Int) {

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/component/OnelineContentView.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/component/OnelineContentView.kt
@@ -31,6 +31,9 @@ class OnelineContentView(context : Context, attrs : AttributeSet) : FrameLayout(
     private var longClick = false
     private var moveAvailable = true
 
+    private var currentPositionX = NOT_INIT_FLOAT
+    private var currentPositionY = NOT_INIT_FLOAT
+
     init {
         val inflater = LayoutInflater.from(context)
         binding = PartialWriteTodayOnelineContentBinding.inflate(inflater, this, true)
@@ -63,6 +66,10 @@ class OnelineContentView(context : Context, attrs : AttributeSet) : FrameLayout(
     fun setToEditMode() {
         binding.edittextWriteTodayOnelineContent.setReadOnly(readOnly = false)
         moveAvailable = false
+    }
+
+    fun initEditTextOnClick(callback : () -> Unit) {
+        binding.edittextWriteTodayOnelineContent.initEditTextOnClick(callback)
     }
 
     // 업로드 중 수정이 불가능 하도록 구현
@@ -124,6 +131,9 @@ class OnelineContentView(context : Context, attrs : AttributeSet) : FrameLayout(
                         (binding.clWriteTodayOnelineContent.x + contentViewWidth / 2) / layoutWidth,
                         (binding.clWriteTodayOnelineContent.y + contentViewHeight / 2)  / layoutHeight
                     )
+
+                    currentPositionX = binding.clWriteTodayOnelineContent.x
+                    currentPositionY = binding.clWriteTodayOnelineContent.y
 
                     if (longClick) {
                         longClick = false

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/component/OnelineEditText.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/component/OnelineEditText.kt
@@ -65,4 +65,10 @@ class OnelineEditText(context : Context, attrs : AttributeSet) : FrameLayout(con
         binding.edittextWriteTodayOnelineEdit.typeface = ResourcesCompat.getFont(context, fontResourceId)
         binding.labelWriteTodayOnelineText.typeface = ResourcesCompat.getFont(context, fontResourceId)
     }
+
+    fun initEditTextOnClick(callback : () -> Unit) {
+        binding.edittextWriteTodayOnelineEdit.setOnClickListener {
+            callback()
+        }
+    }
 }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/model/TodayOnelineWriteScreenState.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/write_today_oneline/write/model/TodayOnelineWriteScreenState.kt
@@ -2,6 +2,6 @@ package com.bookmark.bookmark_oneday.presentation.screens.write_today_oneline.wr
 
 sealed class TodayOnelineWriteScreenState {
     object TextMove : TodayOnelineWriteScreenState()
-    object TextEdit : TodayOnelineWriteScreenState()
+    class TextEdit(val editTextDetailState: EditTextDetailState) : TodayOnelineWriteScreenState()
     object Uploading : TodayOnelineWriteScreenState()
 }

--- a/app/src/main/res/layout/item_today_oneline.xml
+++ b/app/src/main/res/layout/item_today_oneline.xml
@@ -8,6 +8,7 @@
         android:id="@+id/img_today_oneline_background"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:scaleType="centerCrop"
         tools:background="@color/orange"/>
 
     <View


### PR DESCRIPTION
아래 문제 수정
- 키보드가 올라온 상태에서 onPause -> onStart시 키보드가 깜빡거리는 현상
- 오늘한줄 작성 화면으로 이동한 후 돌아온 상황에서 다음 페이지 로딩시 페이지 이동이 발생하지 않는 현상 수정
- 오늘한줄 조회 관련 오늘한줄 데이터를 request Body로의 전환하는 매핑 작업을 repository에서 수행하도록 수정
UI 수정
- 오늘한줄 배경 이미지 scaleType을 fitCenter에서 centerCrop으로 조정
기능 구현
- 소프트 키보드 혹은 폰트 설정 View가 표시될 때, EditText가 가려진 경우 EditText의 위치를 조정