### PR TITLE
Feature book

### DIFF
--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/adapter/mylibrary/MyLibraryBookAdapter.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/adapter/mylibrary/MyLibraryBookAdapter.kt
@@ -1,9 +1,11 @@
 package com.bookmark.bookmark_oneday.presentation.adapter.mylibrary
 
+import android.content.res.ColorStateList
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -89,8 +91,22 @@ class MyLibraryBookNormalViewHolder(
         binding.labelItemMylibraryBookAuthor.text = book.author
         Glide.with(binding.root.context).load(book.thumbnail).into(binding.imgItemMylibraryBookThumbnail)
 
-        binding.imgItemMylibraryLike.visibility = if (book.favorite) View.VISIBLE else View.INVISIBLE
+        setLikeButtonDrawable(book.favorite, book.reading)
         binding.imgItemMylibraryBookmark.visibility = if (book.reading) View.VISIBLE else View.INVISIBLE
+    }
+
+    private fun setLikeButtonDrawable(favorite : Boolean, reading : Boolean) {
+        if (!favorite) {
+            binding.imgItemMylibraryLike.visibility = View.INVISIBLE
+        } else {
+            binding.imgItemMylibraryLike.visibility = View.VISIBLE
+            val tintColor = if (reading) {
+                R.color.white
+            } else {
+                R.color.orange
+            }
+            binding.imgItemMylibraryLike.imageTintList = ColorStateList.valueOf(ContextCompat.getColor(binding.root.context, tintColor))
+        }
     }
 }
 

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/book_detail/BookDetailFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/book_detail/BookDetailFragment.kt
@@ -78,6 +78,7 @@ class BookDetailFragment : ViewBindingFragment<FragmentBookdetailBinding>(Fragme
 
         if (bookState != null) {
             navController.previousBackStackEntry?.savedStateHandle?.set("book_state", BookStateParcelable.fromBookState(bookState))
+            navController.previousBackStackEntry?.savedStateHandle?.set("change_state", listOf(viewModel.bookReadingChanged(), viewModel.bookLikeChanged()))
         }
         navController.popBackStack()
     }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/book_detail/BookDetailFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/book_detail/BookDetailFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.animation.AnimationUtils
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.navArgs
@@ -125,6 +126,10 @@ class BookDetailFragment : ViewBindingFragment<FragmentBookdetailBinding>(Fragme
         binding.btnBookdetailMore.setOnClickListener {
             BookDetailMoreBottomSheetDialog(::showRemoveConfirmDialog).show(childFragmentManager, "BookDetailMoreBottomSheet")
         }
+
+        binding.btnBookdetailLike.setOnClickListener {
+            viewModel.toggleLike()
+        }
     }
 
     private fun showRemoveConfirmDialog() {
@@ -164,12 +169,21 @@ class BookDetailFragment : ViewBindingFragment<FragmentBookdetailBinding>(Fragme
         binding.labelBookdetailReadProgress.text = "${100 - bookDetail.readingPageRatio}%"
         Glide.with(this@BookDetailFragment).load(bookDetail.imageUrl).into(binding.imgBookdetailBookcover)
 
+        setLikeButton(bookDetail.favorite)
+
         binding.labelBookdetailFirstReadDay.text = bookDetail.firstReadTime
         binding.labelBookdetailTotalReadingTime.text = bookDetail.totalTime
 
         binding.pbBookdetailReadpage.progress = bookDetail.readingPageRatio
 
         (binding.listReadinghistory.adapter as BookDetailReadingHistoryAdapter).setReadingHistoryListData(bookDetail.history.groupByDate())
+    }
+
+    private fun setLikeButton(isLike : Boolean) {
+        val likeBtnDrawable = ContextCompat.getDrawable(requireContext(),
+            if (isLike) R.drawable.ic_bookdetail_like_positive else R.drawable.ic_bookdetail_like_negative
+        )
+        binding.btnBookdetailLike.setImageDrawable(likeBtnDrawable)
     }
 
     private fun showLoadingView(show : Boolean) {

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/book_detail/model/BookDetailEvent.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/book_detail/model/BookDetailEvent.kt
@@ -9,4 +9,7 @@ sealed class BookDetailEvent {
     class GetBookDetailSuccess(val bookDetail: BookDetail) : BookDetailEvent()
     class SetPageInfo(val currentPage : Int, val totalPage : Int) : BookDetailEvent()
     class UpdateReadingHistory(val readingHistoryList : List<ReadingHistory>) : BookDetailEvent()
+    object ToggleLikeLoading : BookDetailEvent()
+    object ToggleLikeFail : BookDetailEvent()
+    class ToggleLikeSuccess(val isLike : Boolean) : BookDetailEvent()
 }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/mylibrary/MyLibraryFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/mylibrary/MyLibraryFragment.kt
@@ -169,7 +169,6 @@ class MyLibraryFragment : ViewBindingFragment<FragmentMylibraryBinding>(
             }
 
             savedStateHandle.getLiveData<List<Boolean>>("change_state").observe(viewLifecycleOwner){ changedState ->
-                println("<><> $changedState")
                 val (readingChanged, likeChanged) = changedState
                 viewModel.refreshIfSortTypeIsMatched(readingChanged, likeChanged)
             }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/mylibrary/MyLibraryFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/mylibrary/MyLibraryFragment.kt
@@ -152,14 +152,28 @@ class MyLibraryFragment : ViewBindingFragment<FragmentMylibraryBinding>(
             applyState(state)
         }
 
-        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<BookStateParcelable>("book_state")?.observe(viewLifecycleOwner){
-            viewModel.applyItemChange(it.toBookState())
-        }
 
         viewModel.userProfile.collectLatestInLifecycle(owner = this) { userInfo ->
             Glide.with(requireContext()).load(userInfo.profileImage)
                 .placeholder(R.drawable.ic_all_default_profile)
                 .into(binding.partialMylibraryProfile.imgMylibraryProfile)
+        }
+
+        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<BookStateParcelable>("book_state")?.observe(viewLifecycleOwner){
+            viewModel.applyItemChange(it.toBookState())
+        }
+
+        findNavController().currentBackStackEntry?.savedStateHandle?.let { savedStateHandle ->
+            savedStateHandle.getLiveData<BookStateParcelable>("book_state").observe(viewLifecycleOwner){
+                viewModel.applyItemChange(it.toBookState())
+            }
+
+            savedStateHandle.getLiveData<List<Boolean>>("change_state").observe(viewLifecycleOwner){ changedState ->
+                println("<><> $changedState")
+                val (readingChanged, likeChanged) = changedState
+                viewModel.refreshIfSortTypeIsMatched(readingChanged, likeChanged)
+            }
+
         }
     }
 

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/mylibrary/MyLibraryViewModel.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/mylibrary/MyLibraryViewModel.kt
@@ -67,6 +67,21 @@ class MyLibraryViewModel @Inject constructor(
         }
     }
 
+    /*
+     * 책 상세 화면에서 좋아요 및 읽는 중 여부를 변경했을 때,
+     * 현재 정렬 기준이 '즐겨찾는 책' 혹은 '읽고 있는 책' 인 경우
+     * 전체 목록을 다시 로드해야 하는데, 이 여부를 확인하기 위한 함수입니다.
+     */
+    fun refreshIfSortTypeIsMatched(readingChanged : Boolean, likeChanged : Boolean) {
+        val currentSort = state.value.currentSortData
+        if (
+            readingChanged && currentSort.apiValue == "reading" ||
+            likeChanged && currentSort.apiValue == "favorite"
+        ) {
+            tryGetInitPagingData(currentSort)
+        }
+    }
+
     fun applyItemChange(bookState: BookState) {
         viewModelScope.launch {
             if (!bookState.isRemoved)

--- a/core/room/src/main/java/com/bookmark/bookmark_oneday/core/room/dao/BookDao.kt
+++ b/core/room/src/main/java/com/bookmark/bookmark_oneday/core/room/dao/BookDao.kt
@@ -80,4 +80,6 @@ interface BookDao {
     @Query("SELECT id, timeSec AS time, date FROM ReadingHistory WHERE ReadingHistory.date LIKE :dateQuery || '%' ")
     suspend fun getReadingHistoryByDateQuery(dateQuery : String) : List<HistoryDto>
 
+    @Query("UPDATE registeredBook SET favorite = :like WHERE id = :id")
+    suspend fun updateBookLike(id : Int, like : Boolean)
 }

--- a/core/room/src/main/java/com/bookmark/bookmark_oneday/core/room/dao/BookDao.kt
+++ b/core/room/src/main/java/com/bookmark/bookmark_oneday/core/room/dao/BookDao.kt
@@ -18,9 +18,16 @@ interface BookDao {
         "authors, translators, publisher, bookEntity.backgroundUri AS titleImage, reading, favorite " +
         "FROM registeredBook " +
         "INNER JOIN bookEntity ON bookEntity.isbn = registeredBook.isbn " +
-        "ORDER BY registeredBook.registeredAt DESC LIMIT :pageSize OFFSET :pageIdx * :pageSize"
+        "ORDER BY " +
+            "CASE WHEN :sort = 'latest' THEN registeredBook.registeredAt END DESC," +
+            "CASE WHEN :sort = 'past' THEN registeredBook.registeredAt END ASC, " +
+            "CASE WHEN :sort = 'favorite' THEN registeredBook.favorite END DESC," +
+            "CASE WHEN :sort = 'favorite' THEN registeredBook.registeredAt END DESC," +
+            "CASE WHEN :sort = 'reading' THEN registeredBook.reading END DESC, " +
+            "CASE WHEN :sort = 'reading' THEN registeredBook.registeredAt END DESC " +
+        "LIMIT :pageSize OFFSET :pageIdx * :pageSize"
     )
-    suspend fun getBookItemList(pageIdx: Int, pageSize: Int) : List<BookItemDto>
+    suspend fun getBookItemList(pageIdx: Int, pageSize: Int, sort : String = "latest") : List<BookItemDto>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertRegisteredBook(registeredBook: RegisteredBookEntity)
@@ -55,7 +62,7 @@ interface BookDao {
     @Query("DELETE FROM readingHistory WHERE bookId = :bookId")
     suspend fun deleteAllReadingHistoryOfBook(bookId : Int)
 
-    @Query("UPDATE registeredBook SET currentPage = :currentPage, totalPage = :totalPage WHERE id = :bookId")
+    @Query("UPDATE registeredBook SET currentPage = :currentPage, totalPage = :totalPage, reading = :currentPage > 0 WHERE id = :bookId")
     suspend fun updatePageInfo(bookId : Int, currentPage : Int, totalPage : Int) : Int
 
     @Query("SELECT COALESCE(SUM(timeSec), 0) FROM readingHistory WHERE date LIKE :dateQuery || '%' ")

--- a/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
+++ b/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
@@ -117,7 +117,8 @@ class LocalBookRepository constructor(
                     imageUrl = bookInfo.backgroundUri,
                     totalPage = registeredBook.totalPage,
                     currentPage = registeredBook.currentPage,
-                    history = readingHistory
+                    history = readingHistory,
+                    favorite = registeredBook.favorite
                 )
             )
         } catch (e: Exception) {
@@ -358,6 +359,19 @@ class LocalBookRepository constructor(
                     )
                 }
             )
+        } catch (e : Exception) {
+            return@withContext BaseResponse.Failure(
+                errorCode = -1,
+                errorMessage = "${e.message}"
+            )
+        }
+    }
+
+    override suspend fun updateBookLike(bookId : String, like: Boolean): BaseResponse<Boolean> = withContext(defaultDispatcher) {
+        requireNotNull(bookId.toIntOrNull()) {"bookId must be int : $bookId"}
+        try {
+            bookDao.updateBookLike(bookId.toInt(), like)
+            return@withContext  BaseResponse.Success(data = like)
         } catch (e : Exception) {
             return@withContext BaseResponse.Failure(
                 errorCode = -1,

--- a/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
+++ b/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
@@ -41,7 +41,7 @@ class LocalBookRepository constructor(
         sortType: String
     ): BaseResponse<PagingData<BookItem>> {
         val pageIdx = key.toIntOrNull() ?: throw IllegalArgumentException("page Key must be int : $key")
-        val bookList = bookDao.getBookItemList(pageSize = perPage, pageIdx = pageIdx)
+        val bookList = bookDao.getBookItemList(pageSize = perPage, pageIdx = pageIdx, sort = sortType)
         val amountOfBook = bookDao.getAmountOfRegisteredBook()
 
         return BaseResponse.Success(data = PagingData(
@@ -68,7 +68,7 @@ class LocalBookRepository constructor(
     ): BaseResponse<PagingData<MyLibraryItem.Book>> = withContext(defaultDispatcher) {
         val pageIdx = key.toIntOrNull() ?: throw IllegalArgumentException("page Key must be int : $key")
         try {
-            val bookList = bookDao.getBookItemList(pageSize = perPage, pageIdx = pageIdx)
+            val bookList = bookDao.getBookItemList(pageSize = perPage, pageIdx = pageIdx, sort = sortType)
             val amountOfBook = bookDao.getAmountOfRegisteredBook()
 
             return@withContext BaseResponse.Success(data = PagingData(

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/model/BookDetail.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/model/BookDetail.kt
@@ -9,7 +9,8 @@ data class BookDetail(
     val imageUrl: String,
     val currentPage : Int,
     val totalPage : Int,
-    val history: List<ReadingHistory>
+    val history: List<ReadingHistory>,
+    val favorite : Boolean = false
 ) {
     val readingPageRatio : Int get() {
         return currentPage * 100 / totalPage

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/model/BookState.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/model/BookState.kt
@@ -5,7 +5,7 @@ data class BookState(val bookId : String, val isLike : Boolean, val isReading : 
         fun fromBookDetail(bookDetail: BookDetail, isRemoved : Boolean) : BookState {
             return BookState(
                 bookId = bookDetail.bookId,
-                isLike = false,
+                isLike = bookDetail.favorite,
                 isReading = bookDetail.checkIsReading(),
                 isRemoved = isRemoved
             )

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/repository/BookRepository.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/repository/BookRepository.kt
@@ -25,4 +25,5 @@ interface BookRepository  {
     suspend fun checkDuplicate(isbn : String) : BaseResponse<Nothing>
     suspend fun getReadingHistoryOfMonth(year : Int, month : Int) : BaseResponse<List<ReadingHistory>>
     suspend fun getReadingHistoryWithBookOfDay(year : Int, month : Int, day : Int) : BaseResponse<List<ReadingHistoryWithBook>>
+    suspend fun updateBookLike(bookId : String, like : Boolean) : BaseResponse<Boolean>
 }

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/usecase/UseCaseToggleBookLike.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/usecase/UseCaseToggleBookLike.kt
@@ -1,0 +1,10 @@
+package com.bookmark.bookmark_oneday.domain.book.usecase
+
+import com.bookmark.bookmark_oneday.domain.book.repository.BookRepository
+import javax.inject.Inject
+
+class UseCaseToggleBookLike @Inject constructor(
+    private val repository: BookRepository
+) {
+    suspend operator fun invoke(bookId : String, isLike : Boolean) = repository.updateBookLike(bookId, isLike)
+}


### PR DESCRIPTION
나의 서재(=책 목록 화면) 및 책 상세 화면에 대해 아래 개선사항을 구현하고 문제점을 수정함
- 책 목록 화면에서 정렬 기능 추가
- 책 상세 화면에서 좋아요 혹은 현재 읽는 중 여부가 변경되었을 때, 이전 책 목록 화면의 정렬 기준이 "즐겨찾는 책" 혹은 "읽고있는 책"인 경우 페이지를 다시 로드하도록 구현
- 책 상세 화면에서 좋아요 변경기능 추가