### PR TITLE
타 화면에서 책 추가시 나의 서재 화면에서 이를 감지하여 refresh 하도록 수정

### DIFF
--- a/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
+++ b/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
@@ -18,6 +18,9 @@ import com.bookmark.bookmark_oneday.domain.book.model.RecognizedBook
 import com.bookmark.bookmark_oneday.domain.book.repository.BookRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -34,6 +37,8 @@ class LocalBookRepository constructor(
 
     @SuppressLint("SimpleDateFormat")
     private val dateOnlyFormatter = SimpleDateFormat("yyyy-MM-dd")
+
+    private val _lastUpdateBookListTimeMilli = MutableStateFlow(0L)
 
     override suspend fun getBookList(
         perPage: Int,
@@ -276,6 +281,7 @@ class LocalBookRepository constructor(
                 registeredAt = formatter.format(Calendar.getInstance().time)
             )
             bookDao.insertRegisteredBook(registeredBook)
+            setUpdateBookListTimeMilliToCurrent()
             return@withContext BaseResponse.EmptySuccess
         } catch (e : Exception) {
             return@withContext BaseResponse.Failure(
@@ -367,6 +373,12 @@ class LocalBookRepository constructor(
                 errorMessage = "${e.message}"
             )
         }
+    }
+
+    override fun lastUpdateTimeMilli(): Flow<Long> = _lastUpdateBookListTimeMilli.asStateFlow()
+
+    private fun setUpdateBookListTimeMilliToCurrent() {
+        _lastUpdateBookListTimeMilli.value = Calendar.getInstance().timeInMillis
     }
 
 }

--- a/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
+++ b/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
@@ -141,17 +141,6 @@ class LocalBookRepository constructor(
         }
     }
 
-    override suspend fun removeAllBook(): BaseResponse<Nothing> = withContext(defaultDispatcher) {
-        try {
-            return@withContext BaseResponse.EmptySuccess
-        } catch (e: Exception) {
-            return@withContext BaseResponse.Failure(
-                errorCode = -1,
-                errorMessage = "${e.message}"
-            )
-        }
-    }
-
     override suspend fun updateReadingPage(
         bookId: String,
         currentPage: Int,

--- a/domain/book/build.gradle
+++ b/domain/book/build.gradle
@@ -11,4 +11,5 @@ java {
 dependencies {
     implementation project(":core:model")
     implementation libs.javaxInject
+    implementation libs.coroutineCore
 }

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/repository/BookRepository.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/repository/BookRepository.kt
@@ -9,6 +9,7 @@ import com.bookmark.bookmark_oneday.domain.book.model.ReadingHistory
 import com.bookmark.bookmark_oneday.domain.book.model.ReadingHistoryWithBook
 import com.bookmark.bookmark_oneday.domain.book.model.ReadingInfo
 import com.bookmark.bookmark_oneday.domain.book.model.RecognizedBook
+import kotlinx.coroutines.flow.Flow
 
 interface BookRepository  {
     suspend fun getBookList(perPage : Int = 30, key : String, sortType : String = "latest") : BaseResponse<PagingData<BookItem>>
@@ -25,4 +26,5 @@ interface BookRepository  {
     suspend fun getReadingHistoryOfMonth(year : Int, month : Int) : BaseResponse<List<ReadingHistory>>
     suspend fun getReadingHistoryWithBookOfDay(year : Int, month : Int, day : Int) : BaseResponse<List<ReadingHistoryWithBook>>
     suspend fun updateBookLike(bookId : String, like : Boolean) : BaseResponse<Boolean>
+    fun lastUpdateTimeMilli() : Flow<Long>
 }

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/repository/BookRepository.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/repository/BookRepository.kt
@@ -15,7 +15,6 @@ interface BookRepository  {
     suspend fun getMyLibraryList(perPage : Int = 30, key : String, sortType : String = "latest") : BaseResponse<PagingData<MyLibraryItem.Book>>
     suspend fun getBookDetail(bookId : String) : BaseResponse<BookDetail>
     suspend fun removeBook(bookId : String) : BaseResponse<Nothing>
-    suspend fun removeAllBook() : BaseResponse<Nothing>
     suspend fun updateReadingPage(bookId : String, currentPage : Int, totalPage : Int) : BaseResponse<Nothing>
     suspend fun deleteHistoryItem(bookId : String, targetId : String) : BaseResponse<ReadingInfo>
     suspend fun deleteHistoryAll(bookId: String) : BaseResponse<ReadingInfo>

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/usecase/UseCaseGetBookListUpdateTimeMilli.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/usecase/UseCaseGetBookListUpdateTimeMilli.kt
@@ -1,0 +1,10 @@
+package com.bookmark.bookmark_oneday.domain.book.usecase
+
+import com.bookmark.bookmark_oneday.domain.book.repository.BookRepository
+import javax.inject.Inject
+
+class UseCaseGetBookListUpdateTimeMilli @Inject constructor(
+    private val repository: BookRepository
+) {
+    operator fun invoke() = repository.lastUpdateTimeMilli()
+}


### PR DESCRIPTION
- repository에 마지막 책 목록이 추가된 시간을 flow형식으로 리턴
- useCaseGetLastUpdateBookListTimeMilli의 invoke함수는 위 flow를 그대로 리턴
- viewModel의 init 부분에서 useCaseGetLoastUpdateBookListTimeMilli를 viewModelScope에서 collect한다.
  - viewModel내 저장된 마지막 책 목록 로드 성공 시간과 비교하여 업데이트 시간이 더 최근인 경우 책 목록을 refresh한다.
  - 아닌 경우, 무시한다.