### PR TITLE
Fix reading history

### DIFF
--- a/app/src/main/java/com/bookmark/bookmark_oneday/app/di/data/BookModule.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/app/di/data/BookModule.kt
@@ -1,6 +1,8 @@
 package com.bookmark.bookmark_oneday.app.di.data
 
+import androidx.datastore.core.DataStore
 import com.bookmark.bookmark_oneday.core.api.di.KakaoHttpClient
+import com.bookmark.bookmark_oneday.core.datastore.User
 import com.bookmark.bookmark_oneday.core.room.dao.BookDao
 import com.bookmark.bookmark_oneday.data.book.datasorce.BookInfoDataSource
 import com.bookmark.bookmark_oneday.data.book.datasorce.KakaoBookInfoDataSource
@@ -22,9 +24,10 @@ object BookModule {
     @Singleton
     @Provides
     fun provideLocalBookRepository(
-        bookDao: BookDao
+        bookDao: BookDao,
+        dataStore: DataStore<User>
     ) : BookRepository {
-        return LocalBookRepository(bookDao)
+        return LocalBookRepository(bookDao, dataStore)
     }
 
     @Singleton

--- a/data/book/build.gradle
+++ b/data/book/build.gradle
@@ -33,6 +33,7 @@ android {
 dependencies {
 
     implementation project(":core:api")
+    implementation project(":core:datastore")
     implementation project(":core:room")
     implementation project(":core:model")
     implementation project(":domain:book")
@@ -46,4 +47,5 @@ dependencies {
     implementation libs.bundles.retrofit
 
     implementation libs.javaxInject
+    implementation libs.bundles.protoDataStore
 }

--- a/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
+++ b/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
@@ -39,6 +39,7 @@ class LocalBookRepository constructor(
     private val dateOnlyFormatter = SimpleDateFormat("yyyy-MM-dd")
 
     private val _lastUpdateBookListTimeMilli = MutableStateFlow(0L)
+    private val _lastUpdateReadingHistoryTimeMilli = MutableStateFlow(0L)
 
     override suspend fun getBookList(
         perPage: Int,
@@ -171,6 +172,7 @@ class LocalBookRepository constructor(
         try {
             bookDao.deleteReadingHistory(targetId.toInt())
             val readingInfo = readingInfo(bookId.toInt())
+            setUpdateReadingHistoryTimeMilliToCurrent()
             return@withContext BaseResponse.Success(data = readingInfo)
         } catch (e: Exception) {
             return@withContext BaseResponse.Failure(
@@ -185,6 +187,7 @@ class LocalBookRepository constructor(
         try {
             bookDao.deleteAllReadingHistoryOfBook(bookId.toInt())
             val readingInfo = readingInfo(bookId.toInt())
+            setUpdateReadingHistoryTimeMilliToCurrent()
             return@withContext BaseResponse.Success(data = readingInfo)
         } catch (e: Exception) {
             return@withContext BaseResponse.Failure(
@@ -248,6 +251,7 @@ class LocalBookRepository constructor(
                     timeSec = time
                 )
             )
+            setUpdateReadingHistoryTimeMilliToCurrent()
             val readingInfo = readingInfo(bookId.toInt())
             return@withContext BaseResponse.Success(data = readingInfo)
         } catch (e: Exception) {
@@ -376,9 +380,14 @@ class LocalBookRepository constructor(
     }
 
     override fun lastUpdateTimeMilli(): Flow<Long> = _lastUpdateBookListTimeMilli.asStateFlow()
+    override fun lastUpdateReadingHistoryTimeMilli(): Flow<Long> = _lastUpdateReadingHistoryTimeMilli.asStateFlow()
 
     private fun setUpdateBookListTimeMilliToCurrent() {
         _lastUpdateBookListTimeMilli.value = Calendar.getInstance().timeInMillis
+    }
+
+    private fun setUpdateReadingHistoryTimeMilliToCurrent() {
+        _lastUpdateReadingHistoryTimeMilli.value = Calendar.getInstance().timeInMillis
     }
 
 }

--- a/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
+++ b/data/book/src/main/java/com/bookmark/bookmark_oneday/data/book/repository/LocalBookRepository.kt
@@ -1,6 +1,8 @@
 package com.bookmark.bookmark_oneday.data.book.repository
 
 import android.annotation.SuppressLint
+import androidx.datastore.core.DataStore
+import com.bookmark.bookmark_oneday.core.datastore.User
 import com.bookmark.bookmark_oneday.core.model.BaseResponse
 import com.bookmark.bookmark_oneday.core.model.PagingData
 import com.bookmark.bookmark_oneday.core.model.toTimeString
@@ -21,6 +23,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -29,6 +32,7 @@ import kotlin.coroutines.CoroutineContext
 
 class LocalBookRepository constructor(
     private val bookDao: BookDao,
+    private val dataStore : DataStore<User>,
     private val defaultDispatcher: CoroutineContext = Dispatchers.IO + SupervisorJob()
 ) : BookRepository {
 
@@ -214,8 +218,7 @@ class LocalBookRepository constructor(
 
         val currentTime = Calendar.getInstance().time
         val currentReadingTime = getDailyTotalTime(currentTime)
-        // todo : user 데이터에 접근해 목표 시간 가져오기
-        val dailyGoalTime = 0
+        val dailyGoalTime = dataStore.data.first().targetReadTime * 60
 
         return ReadingInfo(
             dailyGoalTime = dailyGoalTime,

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/repository/BookRepository.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/repository/BookRepository.kt
@@ -27,4 +27,5 @@ interface BookRepository  {
     suspend fun getReadingHistoryWithBookOfDay(year : Int, month : Int, day : Int) : BaseResponse<List<ReadingHistoryWithBook>>
     suspend fun updateBookLike(bookId : String, like : Boolean) : BaseResponse<Boolean>
     fun lastUpdateTimeMilli() : Flow<Long>
+    fun lastUpdateReadingHistoryTimeMilli() : Flow<Long>
 }

--- a/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/usecase/UseCaseGetReadingHistoryUpdateTime.kt
+++ b/domain/book/src/main/java/com/bookmark/bookmark_oneday/domain/book/usecase/UseCaseGetReadingHistoryUpdateTime.kt
@@ -1,0 +1,10 @@
+package com.bookmark.bookmark_oneday.domain.book.usecase
+
+import com.bookmark.bookmark_oneday.domain.book.repository.BookRepository
+import javax.inject.Inject
+
+class UseCaseGetReadingHistoryUpdateTime @Inject constructor(
+    private val repository: BookRepository
+) {
+    operator fun invoke() = repository.lastUpdateReadingHistoryTimeMilli()
+}


### PR DESCRIPTION
독서 기록과 관련된 부분 수정
- 타이머 화면에서 독서 기록 추가 및 삭제시 캘린더 화면에서 이를 감지하여 데이터를 다시 로드하도록 변경
  - 책 목록 업데이트 감지 방식과 동일
- 타이머 화면에 대한 데이터 로드시 사용자의 독서 시간이 누락되어 0으로 전달되었던 부분 수정