### PR TITLE
[fix] 타이머가 화면을 끈 이후에는 실제 시간보다 더 적은 값으로 표시되던 문제 수정

### DIFF
--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/model/Timer.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/model/Timer.kt
@@ -7,14 +7,17 @@ class Timer(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val action : (Int) -> Unit = {}
 ) {
-    private var currentTime = 0
     private var timerJob : Job ?= null
+    private var startTimeMilli = 0L
 
     fun start() {
+        startTimeMilli = System.currentTimeMillis()
         timerJob = coroutineScope.launch(dispatcher) {
             while(true) {
                 delay(1000L)
-                action(++currentTime)
+                val currentTime = System.currentTimeMillis()
+                val timeDiff = ((currentTime - startTimeMilli) / 1000).toInt()
+                action(timeDiff)
             }
         }
     }
@@ -24,6 +27,6 @@ class Timer(
     }
 
     fun resetTime() {
-        currentTime = 0
+        startTimeMilli = 0L
     }
 }


### PR DESCRIPTION
화면을 끈 이후에 타이머가 실제 경과 시간보다 더 적게 표시되던 문제를 수정
- 화면을 종료한 이후에는 프로세스가 할당받는 cpu의 주기가 길어져서 coroutine job이 화면을 켰을 때와 비교하여 더 느리게 수행되었고, 이로 인해서 문제가 발생한 것으로 예상
- count값을 1씩 추가하는 방식에서 coroutine job이 실행될 때마다 현재 시간을 가지고 경과된 시간을 계산하여 사용하는 방식으로 수정