### PR TITLE
시스템 재부팅시 알람이 수신되지 않는 문제 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:allowBackup="true"
@@ -37,7 +38,11 @@
         <activity android:name=".presentation.screens.modify_reading_time.ModifyReadingTimeActivity"/>
         <activity android:name=".presentation.screens.set_alarm.SetAlarmActivity"/>
 
-        <receiver android:name=".presentation.alarm.AlarmReceiver"/>
+        <receiver android:name=".presentation.alarm.AlarmReceiver" android:exported="true">
+            <intent-filter >
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/alarm/AlarmReceiver.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/alarm/AlarmReceiver.kt
@@ -39,7 +39,7 @@ class AlarmReceiver : BroadcastReceiver() {
                     bookMarkAlarmManager.clearAlarm()
                 }
             }
-            Intent.ACTION_REBOOT -> {
+            Intent.ACTION_BOOT_COMPLETED -> {
                 createAlarm()
             }
         }


### PR DESCRIPTION
시스템 재부팅 후 설정한 알람이 정상적으로 수신되지 않는 문제가 발생하여 이를 수정함.
- manifest에 RECEIVE_BOOT_COMPLETED권한 추가
- manifest에 명시된 receiver의 BOOT_COMPLETED intent-filter 추가
- alarmReceiver에서 Intent.ACTION_BOOT_COMPLETED 수신시 알람을 생성하도록 수정