### PR TITLE
달력 화면 recyclerview 관련 수정

### DIFF
--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/adapter/reading_calendar/ReadingCalendarCellAdapter.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/adapter/reading_calendar/ReadingCalendarCellAdapter.kt
@@ -1,10 +1,10 @@
 package com.bookmark.bookmark_oneday.presentation.adapter.reading_calendar
 
-import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.bookmark.bookmark_oneday.R
 import com.bookmark.bookmark_oneday.databinding.ItemReadingCalendarCellBinding
@@ -12,9 +12,7 @@ import com.bookmark.bookmark_oneday.presentation.screens.home.reading_calendar.m
 
 class ReadingCalendarCellAdapter(
     private val onCellClick : (Int, Int, Int) -> Unit
-) : RecyclerView.Adapter<ReadingCalendarCellAdapter.CellViewHolder>(){
-
-    private var cellList = listOf<CalendarCell>()
+) : ListAdapter<CalendarCell, ReadingCalendarCellAdapter.CellViewHolder>(ReadingCalendarCellDiffUtil()){
     private var currentYear : Int = 0
     private var currentMonth : Int = 0
 
@@ -24,18 +22,14 @@ class ReadingCalendarCellAdapter(
         return CellViewHolder(binding)
     }
 
-    override fun getItemCount(): Int = cellList.size
-
     override fun onBindViewHolder(holder: CellViewHolder, position: Int) {
-        holder.bind(cellList[position])
+        holder.bind(getItem(position))
     }
 
-    @SuppressLint("NotifyDataSetChanged")
     fun changeCellData(cellList : List<CalendarCell>, year : Int, month : Int) {
         currentYear = year
         currentMonth = month
-        this.cellList = cellList
-        notifyDataSetChanged()
+        submitList(cellList)
     }
 
     inner class CellViewHolder(
@@ -84,6 +78,17 @@ class ReadingCalendarCellAdapter(
             binding.labelCalendarCellDay.setTextColor(ContextCompat.getColor(binding.root.context, R.color.gray))
         }
 
+    }
+
+}
+
+class ReadingCalendarCellDiffUtil : DiffUtil.ItemCallback<CalendarCell>() {
+    override fun areItemsTheSame(oldItem: CalendarCell, newItem: CalendarCell): Boolean {
+        return "${oldItem.year}_${oldItem.month}_${oldItem.day}" == "${newItem.year}_${newItem.month}_${newItem.day}"
+    }
+
+    override fun areContentsTheSame(oldItem: CalendarCell, newItem: CalendarCell): Boolean {
+        return false
     }
 
 }

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/reading_calendar/ReadingCalendarFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/reading_calendar/ReadingCalendarFragment.kt
@@ -45,9 +45,12 @@ class ReadingCalendarFragment : ViewBindingFragment<FragmentReadingCalendarBindi
         binding.listCalendarCalendar.layoutManager = GridLayoutManager(requireContext(), 7)
         binding.listCalendarCalendar.adapter = ReadingCalendarCellAdapter(viewModel::loadReadingHistoryOfTheDay)
         binding.listCalendarCalendar.addItemDecoration(ReadingCalendarItemDecoration(requireContext()))
+        binding.listCalendarCalendar.setItemViewCacheSize(42)
+        binding.listCalendarCalendar.isNestedScrollingEnabled = false
 
         binding.listCalendarBook.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
         binding.listCalendarBook.adapter = ReadingCalendarBookAdapter()
+        binding.listCalendarBook.isNestedScrollingEnabled = false
     }
 
     private fun initObserver() {

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/reading_calendar/ReadingCalendarFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/reading_calendar/ReadingCalendarFragment.kt
@@ -46,6 +46,7 @@ class ReadingCalendarFragment : ViewBindingFragment<FragmentReadingCalendarBindi
         binding.listCalendarCalendar.adapter = ReadingCalendarCellAdapter(viewModel::loadReadingHistoryOfTheDay)
         binding.listCalendarCalendar.addItemDecoration(ReadingCalendarItemDecoration(requireContext()))
         binding.listCalendarCalendar.setItemViewCacheSize(42)
+        binding.listCalendarCalendar.setHasFixedSize(true)
         binding.listCalendarCalendar.isNestedScrollingEnabled = false
 
         binding.listCalendarBook.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)


### PR DESCRIPTION
달력 화면의 달력 recyclerview의 랜더링이 약간 소요되는 현상이 발생되어 이를 최적화하고자 함
- recyclerView에 사용하는 adapter를 listAdapter로 변경하여 DiffUtil을 사용하는 방식 적용
- setItemViewCacheSize을 사용하여 항상 42개(달력 cell의 최대 개수)를 유지하도록 설정
- 달력의 경우 항상 6줄을 표시하므로 동일한 사이즈를 유지한다. 따라서 setHasFixedSize를 true로 설정