### PR TITLE
오늘한줄 삭제 기능 추가

### DIFF
--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/base/dialog/TwoButtonDialog.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/base/dialog/TwoButtonDialog.kt
@@ -1,0 +1,70 @@
+package com.bookmark.bookmark_oneday.presentation.base.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.DialogFragment
+import com.bookmark.bookmark_oneday.R
+import com.bookmark.bookmark_oneday.databinding.DialogAllTwoButtonBinding
+
+class TwoButtonDialog(
+    private val title : String,
+    private val caption : String,
+    private val leftText : String,
+    private val rightText : String,
+    private val onLeftButtonClick : () -> Unit,
+    private val onRightButtonClick : () -> Unit,
+    private val accentLeft : Boolean = false
+) : DialogFragment() {
+
+    private lateinit var binding : DialogAllTwoButtonBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        binding = DialogAllTwoButtonBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initTextView()
+        initButton()
+    }
+
+    private fun initTextView() {
+        binding.labelAllTwoButtonDialogTitle.text = title
+        binding.labelAllTwoButtonDialogCaption.text = caption
+
+        binding.btnAllTwoButtonDialogLeft.text = leftText
+        binding.btnAllTwoButtonDialogRight.text = rightText
+    }
+
+    private fun initButton() {
+        binding.btnAllTwoButtonDialogLeft.setOnClickListener {
+            onLeftButtonClick()
+            dismiss()
+        }
+
+        binding.btnAllTwoButtonDialogRight.setOnClickListener {
+            onRightButtonClick()
+            dismiss()
+        }
+
+        if (accentLeft) {
+            binding.btnAllTwoButtonDialogLeft.background = ContextCompat.getDrawable(binding.root.context, R.drawable.all_roundbutton_positive)
+            binding.btnAllTwoButtonDialogRight.background = ContextCompat.getDrawable(binding.root.context, R.drawable.all_roundbutton_negative)
+        } else {
+            binding.btnAllTwoButtonDialogLeft.background = ContextCompat.getDrawable(binding.root.context, R.drawable.all_roundbutton_negative)
+            binding.btnAllTwoButtonDialogRight.background = ContextCompat.getDrawable(binding.root.context, R.drawable.all_roundbutton_positive)
+        }
+    }
+}

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/TodayOnelineFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/TodayOnelineFragment.kt
@@ -14,7 +14,9 @@ import com.bookmark.bookmark_oneday.core.presentation.util.toVisibility
 import com.bookmark.bookmark_oneday.databinding.FragmentTodayOnelineBinding
 import com.bookmark.bookmark_oneday.presentation.adapter.today_oneline.TodayOnelineAdapter
 import com.bookmark.bookmark_oneday.presentation.base.DataBindingFragment
+import com.bookmark.bookmark_oneday.presentation.base.dialog.TwoButtonDialog
 import com.bookmark.bookmark_oneday.presentation.screens.home.HomeActivity
+import com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.component.TodayOnelineBottomSheet
 import com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.model.TodayOnelineSideEffect
 import com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.model.ViewPagerPosition
 import com.bookmark.bookmark_oneday.presentation.screens.write_today_oneline.WriteTodayOnelineActivity
@@ -44,7 +46,10 @@ class TodayOnelineFragment : DataBindingFragment<FragmentTodayOnelineBinding>(R.
 
     private fun setButton() {
         binding.partialTodayOnlineToolbar.setMoreButtonEvent {
-            // 신고, 삭제 팝업
+            val moreBottomSheet = TodayOnelineBottomSheet(
+                onRemoveClick = ::callDeleteConfirmDialog
+            )
+            moreBottomSheet.show(childFragmentManager, "OnelineMoreBottomSheet")
         }
 
         binding.partialTodayOnlineToolbar.setWriteButtonEvent {
@@ -52,6 +57,19 @@ class TodayOnelineFragment : DataBindingFragment<FragmentTodayOnelineBinding>(R.
             writeTodayOneLineScreenLauncher.launch(intent)
         }
     }
+
+    private fun callDeleteConfirmDialog() {
+        val deleteConfirmDialog = TwoButtonDialog(
+            title = getString(R.string.label_oneline_delete_dialog),
+            caption = getString(R.string.caption_oneline_delete_dialog),
+            leftText = getString(R.string.label_oneline_delete_dialog_cancel),
+            rightText = getString(R.string.label_oneline_delete_dialog_delete),
+            onLeftButtonClick = {},
+            onRightButtonClick = viewModel::deleteOneline
+        )
+        deleteConfirmDialog.show(childFragmentManager, "onelineDeleteConfirmationDialog")
+    }
+
     private fun setPager() {
         binding.pagerTodayOneline.adapter = TodayOnelineAdapter()
         binding.pagerTodayOneline.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
@@ -104,6 +122,7 @@ class TodayOnelineFragment : DataBindingFragment<FragmentTodayOnelineBinding>(R.
     private fun setObserver() {
         viewModel.state.collectLatestInLifecycle(viewLifecycleOwner) { state ->
             binding.partialTodayOnelineEmpty.root.visibility = state.showEmptyView.toVisibility()
+            binding.partialTodayOnlineToolbar.setOnelineInfoVisible(!state.showEmptyView)
             setLoadingDialogVisibility(state.showLoading)
             state.userProfile?.let { binding.partialTodayOnlineToolbar.setWriterProfile(it) }
             binding.pagerTodayOneline.isUserInputEnabled = !state.showLoading

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/component/TodayOnelineBottomSheet.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/component/TodayOnelineBottomSheet.kt
@@ -1,0 +1,53 @@
+package com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.component
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.bookmark.bookmark_oneday.databinding.BottomsheetTodayOnelineMoreBinding
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class TodayOnelineBottomSheet(
+    private val isWriter : Boolean = true,
+    private val onRemoveClick : () -> Unit = {},
+    private val onReportClick : () -> Unit = {},
+    private val onBookInfoClick : () -> Unit = {}
+) : BottomSheetDialogFragment() {
+    private lateinit var binding : BottomsheetTodayOnelineMoreBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = BottomsheetTodayOnelineMoreBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initButton()
+    }
+
+    private fun initButton() {
+        if (isWriter) {
+            binding.btnOnelineBottomsheetRemove.visibility = View.VISIBLE
+            binding.btnOnelineBottomsheetRemove.setOnClickListener {
+                onRemoveClick()
+                dismiss()
+            }
+        } else {
+            binding.btnOnelineBottomsheetReport.visibility = View.VISIBLE
+            binding.btnOnelineBottomsheetReport.setOnClickListener {
+                onReportClick()
+                dismiss()
+            }
+        }
+
+        binding.btnOnelineBottomsheetBookInfo.setOnClickListener {
+            onBookInfoClick()
+            dismiss()
+        }
+    }
+}

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/component/TodayOnelineToolbar.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/component/TodayOnelineToolbar.kt
@@ -3,6 +3,7 @@ package com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.com
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.bookmark.bookmark_oneday.databinding.PartialTodayOnelineToolbarBinding
 import com.bookmark.bookmark_oneday.domain.oneline.model.UserProfile
@@ -26,6 +27,10 @@ class TodayOnelineToolbar(context : Context, attrs : AttributeSet) : ConstraintL
         binding.btnTodayOnelineMore.setOnClickListener {
             event()
         }
+    }
+
+    fun setOnelineInfoVisible(visible : Boolean) {
+        binding.clTodayOnelineUserInfo.visibility = if (visible) View.VISIBLE else View.INVISIBLE
     }
 
     fun setWriterProfile(userProfile: UserProfile) {

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/model/TodayOnelineEvent.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/model/TodayOnelineEvent.kt
@@ -9,4 +9,7 @@ sealed class TodayOnelineEvent {
     class FirstPageDataLoadingSuccess(val pagingData : PagingData<OneLine>) : TodayOnelineEvent()
     class DataLoadingSuccess(val pagingData : PagingData<OneLine>) : TodayOnelineEvent()
     class ChangePagerPosition(val position : Int) : TodayOnelineEvent()
+    object DeleteLoading : TodayOnelineEvent()
+    object DeleteFail : TodayOnelineEvent()
+    class DeleteSuccess(val id : String) : TodayOnelineEvent()
 }

--- a/app/src/main/res/layout/bottomsheet_today_oneline_more.xml
+++ b/app/src/main/res/layout/bottomsheet_today_oneline_more.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/all_bottomsheetbackground"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <View
+        android:layout_width="42dp"
+        android:layout_height="4dp"
+        android:background="@drawable/all_bottomsheet_handle"
+        app:layout_constraintTop_toTopOf="@id/btn_oneline_bottomsheet_book_info"
+        app:layout_constraintBottom_toTopOf="@id/btn_oneline_bottomsheet_book_info"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/btn_oneline_bottomsheet_book_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="24dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/label_oneline_bottomsheet_book_info"
+        android:textSize="16sp"
+        android:textColor="@color/default_text"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/btn_oneline_bottomsheet_remove"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="24dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/label_oneline_bottomsheet_delete"
+        android:textSize="16sp"
+        android:textColor="#FF0F0F"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/btn_oneline_bottomsheet_book_info"/>
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/btn_oneline_bottomsheet_report"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="24dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/label_oneline_bottomsheet_report"
+        android:textSize="16sp"
+        android:textColor="#FF0F0F"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/btn_oneline_bottomsheet_remove"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_all_two_button.xml
+++ b/app/src/main/res/layout/dialog_all_two_button.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout  xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="320dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/all_dialogbackground"
+        android:paddingVertical="21dp"
+        android:paddingHorizontal="32dp">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/label_all_two_button_dialog_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginTop="10dp"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:text="@string/label_bookconfirm_duplicate_register" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/label_all_two_button_dialog_caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_all_two_button_dialog_title"
+            android:layout_marginTop="10dp"
+            android:textSize="15sp"
+            android:text="@string/caption_bookconfirm_duplicate_register"/>
+
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_all_two_button_dialog_right"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:minHeight="0dp"
+            android:text="@string/label_bookconfirm_register"
+            android:background="@drawable/all_roundbutton_positive"
+            android:textColor="@color/default_background"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:paddingHorizontal="32dp"
+            android:paddingVertical="8dp"
+            android:layout_marginStart="8dp"
+            app:layout_constraintStart_toEndOf="@id/btn_all_two_button_dialog_left"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_all_two_button_dialog_caption"
+            android:layout_marginTop="24dp"/>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_all_two_button_dialog_left"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:minHeight="0dp"
+            android:text="@string/label_bookconfirm_cancel"
+            android:background="@drawable/all_roundbutton_negative"
+            android:textColor="@color/default_background"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:paddingHorizontal="32dp"
+            android:paddingVertical="8dp"
+            android:layout_marginEnd="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/btn_all_two_button_dialog_right"
+            app:layout_constraintTop_toBottomOf="@id/label_all_two_button_dialog_caption"
+            android:layout_marginTop="24dp"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</FrameLayout>

--- a/app/src/main/res/values/strings_oneline.xml
+++ b/app/src/main/res/values/strings_oneline.xml
@@ -2,4 +2,13 @@
 <resources>
     <string name="label_oneline_empty">아직 작성한 한줄 기록이 없어요</string>
     <string name="caption_oneline_empty">우상단의 + 버튼을 클릭해\n등록한 책에 대한 한줄 감상을 남겨보세요</string>
+    
+    <string name="label_oneline_bottomsheet_delete">삭제하기</string>
+    <string name="label_oneline_bottomsheet_report">신고하기</string>
+    <string name="label_oneline_bottomsheet_book_info">책 정보 불러오기</string>
+
+    <string name="label_oneline_delete_dialog">이 한줄을 삭제하실건가요?</string>
+    <string name="caption_oneline_delete_dialog">식제한 한줄을 복구할 수 없습니다.</string>
+    <string name="label_oneline_delete_dialog_cancel">취소</string>
+    <string name="label_oneline_delete_dialog_delete">삭제</string>
 </resources>

--- a/core/room/src/main/java/com/bookmark/bookmark_oneday/core/room/dao/OneLineDao.kt
+++ b/core/room/src/main/java/com/bookmark/bookmark_oneday/core/room/dao/OneLineDao.kt
@@ -32,4 +32,7 @@ interface OneLineDao {
                 "ORDER BY OneLineEntity.createdAt DESC LIMIT :pageSize OFFSET :pageIdx * :pageSize"
     )
     suspend fun getOneLineList(pageIdx : Int, pageSize : Int) : List<OneLineAndBookInfo>
+
+    @Query("DELETE FROM OneLineEntity WHERE id = :id")
+    suspend fun deleteOneline(id : String)
 }

--- a/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/LocalOneLineDataSource.kt
+++ b/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/LocalOneLineDataSource.kt
@@ -97,4 +97,18 @@ class LocalOneLineDataSource @Inject constructor(
                 )
             }
         }
+
+    override suspend fun deleteOneline(id: String): BaseResponse<Nothing> =
+        withContext(defaultDispatcher) {
+            try {
+                oneLineDao.deleteOneline(id)
+                return@withContext BaseResponse.EmptySuccess
+            } catch (e: Exception) {
+                return@withContext BaseResponse.Failure(
+                    errorCode = -1,
+                    errorMessage = "${e.message}"
+                )
+            }
+        }
+
 }

--- a/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/OnelineDataSource.kt
+++ b/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/OnelineDataSource.kt
@@ -9,4 +9,5 @@ interface OnelineDataSource {
     suspend fun getOnelineList(perPage : Int, continuousToken : String, sortType : String) : BaseResponse<PagingData<OneLineDto>>
 
     suspend fun registerOneline(oneLineContent: RegisterOneLineRequestBody) : BaseResponse<Nothing>
+    suspend fun deleteOneline(id : String) : BaseResponse<Nothing>
 }

--- a/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/RemoteOnelineDataSource.kt
+++ b/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/RemoteOnelineDataSource.kt
@@ -11,6 +11,7 @@ import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
@@ -52,6 +53,17 @@ class RemoteOnelineDataSource @Inject constructor(
             BaseResponse.Failure(errorCode, errorMessage)
         }
     }
+
+    override suspend fun deleteOneline(id: String): BaseResponse<Nothing> {
+        val response = service.deleteOneline(id)
+        return if (response.isSuccessful) {
+            BaseResponse.EmptySuccess
+        } else {
+            val errorMessage = response.message()
+            val errorCode = response.code()
+            BaseResponse.Failure(errorCode, errorMessage)
+        }
+    }
 }
 
 interface OnelineApi {
@@ -60,4 +72,7 @@ interface OnelineApi {
 
     @POST("/v1/oneliner")
     suspend fun registerOneline(@Body params : RegisterOneLineRequestBody) : Response<ResponseBody>
+
+    @DELETE("/v1/oneliner")
+    suspend fun deleteOneline(@Query("id") id : String) : Response<ResponseBody>
 }

--- a/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/TestOnelineDataSource.kt
+++ b/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/TestOnelineDataSource.kt
@@ -20,25 +20,6 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
         }
 
         val nextPageToken = continuousToken.toInt()
-//        val tempDataList = List(perPage){
-//            OneLineDto(
-//                id = "$continuousToken-$it",
-//                user_id = "1",
-//                profile_image = null,
-//                nickname = "Test User $continuousToken-$it",
-//                book_id = "1",
-//                title = "Test $continuousToken $it",
-//                authors = listOf("Oauth", "2.0"),
-//                oneliner = "$continuousToken $it 테스트 중입니다~",
-//                color = if (it == 0) "#FF018786" else  "#000000",
-//                top = if (it % 2 == 0) "0.9" else "0",
-//                left = if (it % 3 == 0) "0.9" else "0",
-//                font = "Test",
-//                font_size = (18 + it * 3).toString(),
-//                bg_image_url = null,
-//                created_at = "2023-04-29T11:18:25.801Z"
-//            )
-//        }
 
         val startIndex = perPage * nextPageToken
         val endIndex = perPage * (nextPageToken + 1)
@@ -113,6 +94,11 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
     )
 
     override suspend fun registerOneline(oneLineContent: RegisterOneLineRequestBody): BaseResponse<Nothing> {
+        delay(1500L)
+        return BaseResponse.EmptySuccess
+    }
+
+    override suspend fun deleteOneline(id: String): BaseResponse<Nothing> {
         delay(1500L)
         return BaseResponse.EmptySuccess
     }

--- a/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/repository/OnelineRepositoryImpl.kt
+++ b/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/repository/OnelineRepositoryImpl.kt
@@ -41,4 +41,8 @@ class OnelineRepositoryImpl @Inject constructor(
         val requestBody = RegisterOneLineRequestBody.fromOnelineContent(oneLineContent = oneLineContent)
         return dataSource.registerOneline(requestBody)
     }
+
+    override suspend fun deleteOneline(id: String): BaseResponse<Nothing> {
+        return dataSource.deleteOneline(id = id)
+    }
 }

--- a/domain/oneline/src/main/java/com/bookmark/bookmark_oneday/domain/oneline/repository/OnelineRepository.kt
+++ b/domain/oneline/src/main/java/com/bookmark/bookmark_oneday/domain/oneline/repository/OnelineRepository.kt
@@ -7,6 +7,6 @@ import com.bookmark.bookmark_oneday.domain.oneline.model.OneLineContent
 
 interface OnelineRepository {
     suspend fun getOnelineList(perPage : Int= 5, key : String, sortType : String = "latest") : BaseResponse<PagingData<OneLine>>
-
     suspend fun registerOneLine(oneLineContent: OneLineContent) : BaseResponse<Nothing>
+    suspend fun deleteOneline(id : String) : BaseResponse<Nothing>
 }

--- a/domain/oneline/src/main/java/com/bookmark/bookmark_oneday/domain/oneline/usecase/UseCaseDeleteOneline.kt
+++ b/domain/oneline/src/main/java/com/bookmark/bookmark_oneday/domain/oneline/usecase/UseCaseDeleteOneline.kt
@@ -1,0 +1,13 @@
+package com.bookmark.bookmark_oneday.domain.oneline.usecase
+
+import com.bookmark.bookmark_oneday.core.model.BaseResponse
+import com.bookmark.bookmark_oneday.domain.oneline.repository.OnelineRepository
+import javax.inject.Inject
+
+class UseCaseDeleteOneline @Inject constructor(
+    private val repository: OnelineRepository
+) {
+    suspend operator fun invoke(id : String) : BaseResponse<Nothing> {
+        return repository.deleteOneline(id)
+    }
+}


### PR DESCRIPTION
- 삭제 관련 repository, datasource에 새 메소드 작성
- 오늘한줄 삭제 관련 useCase 추가
- 오늘한줄 삭제시 사용되는 UI 추가
  - 오늘한줄 사용자 정보에 더보기를 클릭하면 표시되는 bottomSheet
  - bottomSheet에서 삭제하기를 클릭하면 삭제를 다시한번 확인하는 dialog
- 오늘한줄 화면에서 아직 작성한 데이터가 없을 경우 오늘한줄 작성자 정보 부분을 숨김처리하도록 수정