### PR TITLE
오늘한줄에서 더보기-책정보 불러오기 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
         <activity android:name=".presentation.screens.modify_profile.ModifyProfileActivity"/>
         <activity android:name=".presentation.screens.modify_reading_time.ModifyReadingTimeActivity"/>
         <activity android:name=".presentation.screens.set_alarm.SetAlarmActivity"/>
+        <activity android:name=".presentation.screens.book_confirmation_oneline.BookConfirmationFromOnelineActivity"/>
 
         <receiver android:name=".presentation.alarm.AlarmReceiver" android:exported="true">
             <intent-filter >

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/base/dialog/OneButtonDialog.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/base/dialog/OneButtonDialog.kt
@@ -1,0 +1,50 @@
+package com.bookmark.bookmark_oneday.presentation.base.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.bookmark.bookmark_oneday.databinding.DialogAllOneButtonBinding
+
+class OneButtonDialog(
+    private val title : String,
+    private val caption : String,
+    private val buttonText : String,
+    private val buttonClick : () -> Unit
+) : DialogFragment() {
+    private lateinit var binding : DialogAllOneButtonBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        binding = DialogAllOneButtonBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initTextView()
+        initButton()
+    }
+
+    private fun initTextView() {
+        binding.labelAllOneButtonDialogTitle.text = title
+        binding.labelAllOneButtonDialogCaption.text = caption
+
+        binding.btnAllOneButtonDialog.text = buttonText
+    }
+
+    private fun initButton() {
+        binding.btnAllOneButtonDialog.setOnClickListener {
+            dismiss()
+            buttonClick()
+        }
+    }
+}

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/book_confirmation_oneline/BookConfirmationFromOnelineActivity.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/book_confirmation_oneline/BookConfirmationFromOnelineActivity.kt
@@ -1,0 +1,78 @@
+package com.bookmark.bookmark_oneday.presentation.screens.book_confirmation_oneline
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.View
+import androidx.activity.viewModels
+import com.bookmark.bookmark_oneday.R
+import com.bookmark.bookmark_oneday.databinding.ActivityBookConfirmationBinding
+import com.bookmark.bookmark_oneday.domain.book.model.RecognizedBook
+import com.bookmark.bookmark_oneday.presentation.base.ViewBindingActivity
+import com.bookmark.bookmark_oneday.presentation.base.dialog.OneButtonDialog
+import com.bookmark.bookmark_oneday.presentation.util.collectLatestInLifecycle
+import com.bumptech.glide.Glide
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BookConfirmationFromOnelineActivity : ViewBindingActivity<ActivityBookConfirmationBinding>(ActivityBookConfirmationBinding::inflate) {
+    private val viewModel : BookConfirmationFromOnelineViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        initView()
+        initObserver()
+        initButton()
+
+        handleNavigationParameter()
+    }
+
+    private fun initView() {
+        binding.btnBookconfirmConfirm.visibility = View.INVISIBLE
+    }
+
+    private fun initObserver() {
+        viewModel.state.collectLatestInLifecycle(this) {state ->
+            state.recognizedBook?.let { applyBookData(it) }
+        }
+    }
+
+    private fun initButton() {
+        binding.btnBookconfirmBack.setOnClickListener {
+            finish()
+        }
+    }
+
+    private fun handleNavigationParameter() {
+        val isbn = intent.getStringExtra("isbn")
+        if (isbn == null) {
+            callEmptyParameterDialog()
+        } else {
+            viewModel.searchBook(isbn)
+        }
+    }
+
+    private fun callEmptyParameterDialog() {
+        val dialog = OneButtonDialog(
+            title = getString(R.string.label_bookconfirm_cannot_founc_book_info),
+            caption = getString(R.string.caption_bookconfirm_cannot_found_book_info),
+            buttonText = getString(R.string.label_bookconfirm_confirm),
+            buttonClick = {
+                finish()
+            }
+        )
+        dialog.show(supportFragmentManager, "bookconfirmParameterErrorDialog")
+    }
+
+    @SuppressLint("SetTextI18n")
+    private fun applyBookData(book: RecognizedBook) {
+        binding.labelBookconfirmTitle.text = book.title
+        binding.labelBookconfirmAuthor.text = book.authors.joinToString(", ")
+
+        binding.labelBookconfirmSummary.text = book.content + "..."
+        Glide.with(this).load(book.thumbnail_url).into(binding.imgBookdetailBookcover)
+
+        binding.labelBookconfirmPublisher.text = book.publisher
+        binding.labelBookconfirmPublishDate.text = book.dateTime
+    }
+}

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/book_confirmation_oneline/BookConfirmationFromOnelineViewModel.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/book_confirmation_oneline/BookConfirmationFromOnelineViewModel.kt
@@ -1,0 +1,53 @@
+package com.bookmark.bookmark_oneday.presentation.screens.book_confirmation_oneline
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bookmark.bookmark_oneday.core.model.BaseResponse
+import com.bookmark.bookmark_oneday.domain.book.usecase.UseCaseSearchBookInfo
+import com.bookmark.bookmark_oneday.presentation.screens.book_confirmation_oneline.model.BookConfirmOnelineEvent
+import com.bookmark.bookmark_oneday.presentation.screens.book_confirmation_oneline.model.BookConfirmOnelineState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.runningFold
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BookConfirmationFromOnelineViewModel @Inject constructor(
+    private val useCaseSearchBookInfo: UseCaseSearchBookInfo
+): ViewModel() {
+    private val events = Channel<BookConfirmOnelineEvent>()
+
+    val state : StateFlow<BookConfirmOnelineState> = events.receiveAsFlow()
+        .runningFold(BookConfirmOnelineState(), ::reduce).stateIn(viewModelScope, SharingStarted.Eagerly, BookConfirmOnelineState())
+
+    fun searchBook(isbn : String) {
+        viewModelScope.launch {
+            events.send(BookConfirmOnelineEvent.LoadingBookSearch)
+            val response = useCaseSearchBookInfo(isbn)
+            if (response is BaseResponse.Success) {
+                events.send(BookConfirmOnelineEvent.BookSearchSuccess(response.data))
+            } else {
+                events.send(BookConfirmOnelineEvent.BookSearchFail)
+            }
+        }
+    }
+
+    private fun reduce(state : BookConfirmOnelineState, event : BookConfirmOnelineEvent) : BookConfirmOnelineState {
+        return when (event) {
+            BookConfirmOnelineEvent.LoadingBookSearch -> {
+                state.copy(showLoading = true, showError = false)
+            }
+            BookConfirmOnelineEvent.BookSearchFail -> {
+                state.copy(showLoading = false, showError = true)
+            }
+            is BookConfirmOnelineEvent.BookSearchSuccess -> {
+                state.copy(recognizedBook = event.recognizedBook, showLoading = false, showError = false)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/book_confirmation_oneline/model/BookConfirmOnelineEvent.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/book_confirmation_oneline/model/BookConfirmOnelineEvent.kt
@@ -1,0 +1,9 @@
+package com.bookmark.bookmark_oneday.presentation.screens.book_confirmation_oneline.model
+
+import com.bookmark.bookmark_oneday.domain.book.model.RecognizedBook
+
+sealed class BookConfirmOnelineEvent {
+    object LoadingBookSearch : BookConfirmOnelineEvent()
+    object BookSearchFail : BookConfirmOnelineEvent()
+    class BookSearchSuccess(val recognizedBook: RecognizedBook) : BookConfirmOnelineEvent()
+}

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/book_confirmation_oneline/model/BookConfirmOnelineState.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/book_confirmation_oneline/model/BookConfirmOnelineState.kt
@@ -1,0 +1,9 @@
+package com.bookmark.bookmark_oneday.presentation.screens.book_confirmation_oneline.model
+
+import com.bookmark.bookmark_oneday.domain.book.model.RecognizedBook
+
+data class BookConfirmOnelineState(
+    val recognizedBook: RecognizedBook ?= null,
+    val showLoading : Boolean = false,
+    val showError : Boolean = false
+)

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/TodayOnelineFragment.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/TodayOnelineFragment.kt
@@ -15,6 +15,7 @@ import com.bookmark.bookmark_oneday.databinding.FragmentTodayOnelineBinding
 import com.bookmark.bookmark_oneday.presentation.adapter.today_oneline.TodayOnelineAdapter
 import com.bookmark.bookmark_oneday.presentation.base.DataBindingFragment
 import com.bookmark.bookmark_oneday.presentation.base.dialog.TwoButtonDialog
+import com.bookmark.bookmark_oneday.presentation.screens.book_confirmation_oneline.BookConfirmationFromOnelineActivity
 import com.bookmark.bookmark_oneday.presentation.screens.home.HomeActivity
 import com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.component.TodayOnelineBottomSheet
 import com.bookmark.bookmark_oneday.presentation.screens.home.today_oneline.model.TodayOnelineSideEffect
@@ -47,7 +48,8 @@ class TodayOnelineFragment : DataBindingFragment<FragmentTodayOnelineBinding>(R.
     private fun setButton() {
         binding.partialTodayOnlineToolbar.setMoreButtonEvent {
             val moreBottomSheet = TodayOnelineBottomSheet(
-                onRemoveClick = ::callDeleteConfirmDialog
+                onRemoveClick = ::callDeleteConfirmDialog,
+                onBookInfoClick = ::goToBookConfirmation
             )
             moreBottomSheet.show(childFragmentManager, "OnelineMoreBottomSheet")
         }
@@ -68,6 +70,13 @@ class TodayOnelineFragment : DataBindingFragment<FragmentTodayOnelineBinding>(R.
             onRightButtonClick = viewModel::deleteOneline
         )
         deleteConfirmDialog.show(childFragmentManager, "onelineDeleteConfirmationDialog")
+    }
+
+    private fun goToBookConfirmation() {
+        val isbn = viewModel.getCurrentOnelineBookIsbn() ?: return
+        val intent = Intent(requireContext(), BookConfirmationFromOnelineActivity::class.java)
+        intent.putExtra("isbn", isbn)
+        startActivity(intent)
     }
 
     private fun setPager() {

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/TodayOnelineViewModel.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/screens/home/today_oneline/TodayOnelineViewModel.kt
@@ -117,6 +117,10 @@ class TodayOnelineViewModel @Inject constructor(
         }
     }
 
+    fun getCurrentOnelineBookIsbn() : String? {
+        return state.value.onelineList.getOrNull(currentPageIdx ?: 0)?.bookIsbn
+    }
+
     private fun reduce(state : TodayOnelineState, event: TodayOnelineEvent) : TodayOnelineState {
         return when (event) {
             is TodayOnelineEvent.ChangePagerPosition -> {

--- a/app/src/main/res/layout/dialog_all_one_button.xml
+++ b/app/src/main/res/layout/dialog_all_one_button.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout  xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="320dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/all_dialogbackground"
+        android:paddingVertical="21dp"
+        android:paddingHorizontal="32dp">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/label_all_one_button_dialog_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginTop="10dp"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:text="@string/label_all_empty_placeholder" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/label_all_one_button_dialog_caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_all_one_button_dialog_title"
+            android:layout_marginTop="10dp"
+            android:textSize="15sp"
+            android:text="@string/label_all_empty_placeholder"/>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_all_one_button_dialog"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:minHeight="0dp"
+            android:text="@string/label_all_empty_placeholder"
+            android:background="@drawable/all_roundbutton_positive"
+            android:textColor="@color/default_background"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:paddingHorizontal="32dp"
+            android:paddingVertical="8dp"
+            android:layout_marginStart="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_all_one_button_dialog_caption"
+            android:layout_marginTop="24dp"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="caption_bookrecognition_scan_barcode">책의 바코드를 인식해 주세요.</string>
     <string name="label_bookrecognition_scan_fail">인식 실패</string>
     <string name="caption_bookrecognition_scan_fail">바코드가 인식되지 않습니다.</string>
-    <string name="label_bookrecognition_confirm">확인</string>인
+    <string name="label_bookrecognition_confirm">확인</string>
 
     <string name="label_bookconfirm_register">등록</string>
     <string name="label_bookconfirm_cancel">취소</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="caption_bookrecognition_scan_barcode">책의 바코드를 인식해 주세요.</string>
     <string name="label_bookrecognition_scan_fail">인식 실패</string>
     <string name="caption_bookrecognition_scan_fail">바코드가 인식되지 않습니다.</string>
-    <string name="label_bookrecognition_confirm">확인</string>
+    <string name="label_bookrecognition_confirm">확인</string>인
 
     <string name="label_bookconfirm_register">등록</string>
     <string name="label_bookconfirm_cancel">취소</string>
@@ -127,4 +127,10 @@
     <string name="html_caption_modify_reading_time_more"><![CDATA[2022년 성인 기준\n평균보다 <font color="#F99030">%d분</font>많아요]]></string>
     <string name="html_caption_modify_reading_time_less"><![CDATA[2022년 성인 기준\n평균보다 <font color="#F99030">%d분</font>적어요]]></string>
     <string name="label_modify_reading_time_complete">완료</string>
+
+    <string name="label_all_empty_placeholder">-</string>
+
+    <string name="label_bookconfirm_cannot_founc_book_info">조회 실패</string>
+    <string name="caption_bookconfirm_cannot_found_book_info">책 정보를 조회할 수 없습니다.\n잠시 후에 다시 시도해주세요.</string>
+    <string name="label_bookconfirm_confirm">확인</string>
 </resources>

--- a/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/LocalOneLineDataSource.kt
+++ b/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/LocalOneLineDataSource.kt
@@ -46,7 +46,7 @@ class LocalOneLineDataSource @Inject constructor(
                                user_id = "0",
                                profile_image = userInfo.profileUri,
                                nickname = userInfo.nickname,
-                               book_id = it.isbn,
+                               book_isbn = it.isbn,
                                title = it.title,
                                authors = it.authors,
                                oneliner = it.oneliner,

--- a/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/TestOnelineDataSource.kt
+++ b/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/datasource/TestOnelineDataSource.kt
@@ -39,7 +39,7 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
     private val testOnelineList = listOf(
         OneLineDto(
             id = "1", user_id = "1", profile_image = null,
-            nickname = "플레이스", book_id = "1",
+            nickname = "플레이스", book_isbn = "1",
             title = "차라투스트라는 이렇게 말했다", authors = listOf("프리드리히 니체"),
             oneliner = "사랑에는 늘 약간의 망상이 들어 있다.", color = "#ffffff",
             top = "0.5", left = "0.5", font = "Test", font_size = "18",
@@ -48,7 +48,7 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
         ),
         OneLineDto(
             id = "2", user_id = "1", profile_image = null,
-            nickname = "더파인애플", book_id = "1",
+            nickname = "더파인애플", book_isbn = "1",
             title = "여행의 이유", authors = listOf("김영하"),
             oneliner = "여행가고싶다", color = "#ffffff",
             top = "0.0", left = "0.0", font = "Test", font_size = "24",
@@ -57,7 +57,7 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
         ),
         OneLineDto(
             id = "3", user_id = "1", profile_image = null,
-            nickname = "프로브", book_id = "1",
+            nickname = "프로브", book_isbn = "1",
             title = "Clean Code(클린 코드)", authors = listOf("로버트 C. 마틴"),
             oneliner = "clean code, clean state", color = "#000000",
             top = "0.40", left = "0.08", font = "Test", font_size = "30",
@@ -66,7 +66,7 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
         ),
         OneLineDto(
             id = "4", user_id = "1", profile_image = null,
-            nickname = "플레이스", book_id = "1",
+            nickname = "플레이스", book_isbn = "1",
             title = "차라투스트라는 이렇게 말했다", authors = listOf("프리드리히 니체"),
             oneliner = "사랑에는 늘 약간의 망상이 들어 있다.", color = "#ffffff",
             top = "0.5", left = "0.5", font = "Test", font_size = "18",
@@ -75,7 +75,7 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
         ),
         OneLineDto(
             id = "5", user_id = "1", profile_image = null,
-            nickname = "더파인애플", book_id = "1",
+            nickname = "더파인애플", book_isbn = "1",
             title = "여행의 이유", authors = listOf("김영하"),
             oneliner = "여행가고싶다", color = "#ffffff",
             top = "0.0", left = "0.0", font = "Test", font_size = "24",
@@ -84,7 +84,7 @@ class TestOnelineDataSource @Inject constructor() : OnelineDataSource {
         ),
         OneLineDto(
             id = "6", user_id = "1", profile_image = null,
-            nickname = "프로브", book_id = "1",
+            nickname = "프로브", book_isbn = "1",
             title = "Clean Code(클린 코드)", authors = listOf("로버트 C. 마틴"),
             oneliner = "clean code, clean state", color = "#000000",
             top = "0.40", left = "0.08", font = "Test", font_size = "30",

--- a/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/model/dto/OneLineDto.kt
+++ b/data/oneline/src/main/java/com/bookmark/bookmark_oneday/data/oneline/model/dto/OneLineDto.kt
@@ -8,7 +8,7 @@ data class OneLineDto(
     val user_id : String,
     val profile_image : String?,
     val nickname : String,
-    val book_id : String,
+    val book_isbn : String,
     val title : String,
     val authors : List<String>,
     val oneliner : String,
@@ -32,7 +32,7 @@ data class OneLineDto(
             return OneLine(
                 id = oneLineDto.id,
                 userProfile = userProfile,
-                bookId = oneLineDto.book_id,
+                bookIsbn = oneLineDto.book_isbn,
                 bookInfo = bookInfo,
                 oneliner = oneLineDto.oneliner,
                 textColor = oneLineDto.color,

--- a/domain/oneline/src/main/java/com/bookmark/bookmark_oneday/domain/oneline/model/OneLine.kt
+++ b/domain/oneline/src/main/java/com/bookmark/bookmark_oneday/domain/oneline/model/OneLine.kt
@@ -5,7 +5,7 @@ import com.bookmark.bookmark_oneday.core.model.TimeString
 data class OneLine(
     val id : String,
     val userProfile: UserProfile,
-    val bookId : String,
+    val bookIsbn : String,
     val bookInfo : String,
     val oneliner : String,
     val textColor : String,


### PR DESCRIPTION
- 기존 BookConfirmActivity와 xml을 공유하는 BookConfirmFromOnelineActivity 구현
  - BookConfirmActivity의 경우, 이전 화면에서 책을 인식한 후 해당 책 정보를 직렬화해서 전달받는 반면,
  - BookConfirmFromOnelineActivity의 경우 이전 화면에서 isbn만을 전달받은 후 해당 isbn을 가지고 책 정보를 onCreate에서 조회함
  - BookConfirmActivity에는 책을 나의 서재에 등록하는 버튼이 존해자는 반면,
  - BookConfirmFromOnelineActivity의 경우 해당 버튼이 표시되지 않음
 - BookConfirmFromOnelineActivity에서 사용되는 OneButtonDialog 구현