### PR TITLE
Fix alarm

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission
+        android:name="android.permission.POST_NOTIFICATIONS"
+        android:minSdkVersion="33"/>
 
     <application
         android:allowBackup="true"
@@ -18,7 +21,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.BookmarkOneday"
-        tools:targetApi="31">
+        tools:targetApi="33">
 
         <activity android:name=".presentation.screens.splash.SplashActivity" android:exported="true">
             <intent-filter>
@@ -42,6 +45,9 @@
         <receiver android:name=".presentation.alarm.AlarmReceiver" android:exported="true">
             <intent-filter >
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.app.action.SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/java/com/bookmark/bookmark_oneday/presentation/util/PermissionUtils.kt
+++ b/app/src/main/java/com/bookmark/bookmark_oneday/presentation/util/PermissionUtils.kt
@@ -25,11 +25,25 @@ val EXACT_ALARM_PERMISSION =
         null
     }
 
-
 fun checkExactAlarmAvailable(context : Context) : Boolean {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         alarmManager.canScheduleExactAlarms()
+    } else {
+        true
+    }
+}
+
+val POST_NOTIFICATIONS_33 =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.POST_NOTIFICATIONS
+    } else {
+        null
+    }
+
+fun checkPostNotificationAvailable(context : Context) : Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
     } else {
         true
     }

--- a/app/src/main/res/values/strings_alarm.xml
+++ b/app/src/main/res/values/strings_alarm.xml
@@ -12,4 +12,9 @@
     <string name="label_time_of_day_am_format">오전 %d시 %d분</string>
     <string name="label_time_of_day_night_format">밤 %d시 %d분</string>
     <string name="label_time_of_day_afternoon_format">낮 %d시 %d분</string>
+
+    <string name="label_notify_require_permissions_for_alarm">알림 권한 요청</string>
+    <string name="caption_notify_require_permissions_for_alarm">정확한 시간에 알림을 보내기 위해서는 권한이 필요합니다.\n알림을 사용하려면 권한을 허용해주세요.\n"이동"버튼을 누르면 설정 화면으로 이동합니다.</string>
+    <string name="moving">이동</string>
+    <string name="cancel">취소</string>
 </resources>


### PR DESCRIPTION
알람 관련 아래 항목 수정
- manifest에서 알람 권한이 누락된 부분 추가
- PermissionUtils에 android sdk 버젼이 33이상일 때만 POST_NOTIFICATION 권한을 체크하도록 하는 코드 작성
- 알람 거부시 다이럴로그를 표시하도록 구현
  - 다이럴로그에서 "이동" 버튼을 누를 경우, 권한 설정 화면으로 이동

https://developer.android.com/about/versions/14/changes/schedule-exact-alarms?hl=ko#migration  
android 14이상의 변동사항 중 하나인 정확한 알림 예약 권한에 대한 아래 작업들을 수행
- 알람을 설정할 때, canScheduleExactAlarms를 사용해 정확한 알림을 사용할 수 없을 경우 알람을 생성하는 것 대신, 정확한 알림을 설정하는 설정 화면으로 이동하도록 하는 다이럴로그 표시